### PR TITLE
take scrot screenshot without beep

### DIFF
--- a/my-i3lock-config.sh
+++ b/my-i3lock-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PICTURE=/tmp/i3lock.png
-SCREENSHOT="scrot $PICTURE"
+SCREENSHOT="scrot -z $PICTURE"
 
 BLUR="5x4"
 


### PR DESCRIPTION
By using the `-z` flag on the `scrot` screenshot line, the tool will no longer emit a beep upon locking.